### PR TITLE
Fix strptime pattern

### DIFF
--- a/time_parser.py
+++ b/time_parser.py
@@ -1,7 +1,7 @@
 import time, re
 def parse(s):
 
-    t = time.strptime(s, '%a %b %d %Y %H:%M:%S %p.%f')
+    t = time.strptime(s, '%a %b %d %Y %I:%M:%S %p.%f')
     reg = re.compile('\.\\d{3}')
     if (reg.search(s)):
         ms = float(reg.search(s).group(0))


### PR DESCRIPTION
Hi, I found your project by searching for "strptime," "%H," and "%p" on GitHub. Changing %H to %I as detailed in this pull request will fix time parsing, as using "%H" with 12-hour times will ignore AM/PM and always give you the AM equivalent, even when %p is in the format string. I was bit by the same issue earlier today. Hope this helps!
